### PR TITLE
Feature/template specific paths

### DIFF
--- a/commands/config-aware.command.ts
+++ b/commands/config-aware.command.ts
@@ -1,23 +1,54 @@
 import { AbstractCommand } from './abstract.command';
-import { getConfigGetter, type GetRcFieldValue } from '../lib/utils/rc.util';
+import { getConfigGetter as getRcConfigGetter, type GetRcFieldValue } from '../lib/utils/rc.util';
+import {
+  getConfigGetter as getTemplateConfigGetter,
+  type GetTemplateConfigFieldValue,
+} from '../lib/utils/template-config.util';
 
 export abstract class ConfigAwareCommand extends AbstractCommand {
-  protected _getConfig: Awaited<ReturnType<typeof getConfigGetter>>;
+  protected _getConfig: Awaited<ReturnType<typeof getRcConfigGetter>>;
 
-  protected async loadConfig() {
-    if (this.isConfigLoaded()) return;
-    this._getConfig = await getConfigGetter(process.cwd());
+  protected _getTemplateConfig: Awaited<ReturnType<typeof getTemplateConfigGetter>>;
+
+  protected async loadRcConfig() {
+    if (this.isRcConfigLoaded()) return;
+    this._getConfig = await getRcConfigGetter(process.cwd());
   }
 
-  protected isConfigLoaded() {
+  protected isRcConfigLoaded() {
     return !!this._getConfig;
   }
 
-  protected getConfig<TData>(cb: GetRcFieldValue<TData>, defaultValue?: TData) {
+  protected getRc<TData>(cb: GetRcFieldValue<TData>, defaultValue?: TData) {
     if (!this._getConfig) {
       throw new Error('Config is not loaded. Please call loadConfig() before getConfig()');
     }
 
     return this._getConfig(cb, defaultValue);
+  }
+
+  protected async loadTemplateConfig() {
+    if (!this.isRcConfigLoaded()) {
+      throw new Error(
+        'Rc Config is not loaded. Template Config cannot be loaded without Rc Config.',
+      );
+    }
+    if (this.isTemplateConfigLoaded()) return;
+    this._getTemplateConfig = await getTemplateConfigGetter(
+      process.cwd(),
+      this.getRc((rc) => rc?.outDir),
+    );
+  }
+
+  protected isTemplateConfigLoaded() {
+    return !!this._getTemplateConfig;
+  }
+
+  protected getTemplateConfig<TData>(cb: GetTemplateConfigFieldValue<TData>, defaultValue?: TData) {
+    if (!this._getTemplateConfig) {
+      throw new Error('Template Config is not loaded. Please call loadConfig() before getConfig()');
+    }
+
+    return this._getTemplateConfig(cb, defaultValue);
   }
 }

--- a/commands/init.command.ts
+++ b/commands/init.command.ts
@@ -31,8 +31,7 @@ export class InitCommand extends ConfigAwareCommand {
     this.templateOutputPath = join(this.templatePath, templateFilesPath);
 
     if (!pathExists(this.templatePath)) {
-      const templateRepository = this.getConfig((rc) => rc?.template?.repository);
-      await this.spawnAndWaitAndStopIfError('git', ['clone', templateRepository, outDir]);
+      await this.cloneRepository();
       console.log(chalk.green('Successfully Cloned Template'));
       await this.spawnAndWaitAndStopIfError('npm', ['install'], {
         cwd: outDir,
@@ -60,5 +59,23 @@ export class InitCommand extends ConfigAwareCommand {
   protected async createGitIgnoreFile() {
     const itemsToIgnore = [this.getConfig((rc) => rc?.outDir)];
     await addToGitIgnore(this.workingDirectory, itemsToIgnore);
+  }
+
+  protected async cloneRepository() {
+    const outDir = this.getConfig((rc) => rc?.outDir);
+    const templateRepository = this.getConfig((rc) => rc?.template?.repository);
+    const branchName = this.getConfig((rc) => rc?.template?.branch);
+
+    let extraOptions = [];
+    if (branchName) {
+      extraOptions = ['-b', branchName];
+    }
+
+    return await this.spawnAndWaitAndStopIfError('git', [
+      'clone',
+      templateRepository,
+      outDir,
+      ...extraOptions,
+    ]);
   }
 }

--- a/commands/watch.command.ts
+++ b/commands/watch.command.ts
@@ -26,7 +26,7 @@ export class WatchCommand extends InitCommand {
 
     this.workingDirectory = process.cwd();
 
-    const templateFilesPath = this.getConfig((rc) => rc?.template?.filesPath);
+    const templateFilesPath = this.getRc((rc) => rc?.template?.filesPath);
     this.templateOutputPath = join(this.templatePath, templateFilesPath);
 
     await Promise.all([this.startDevServer(), this.watchFiles(), this.startContentLayer()]);

--- a/lib/utils/fs.util.ts
+++ b/lib/utils/fs.util.ts
@@ -7,7 +7,7 @@ import {
   unlink,
   appendFile,
 } from 'fs/promises';
-import { existsSync } from 'fs';
+import { existsSync, rmSync } from 'fs';
 import { EOL } from 'os';
 
 export async function readFile(...paths: string[]) {
@@ -21,8 +21,8 @@ export async function readFileInJson<TData = any>(...params: Parameters<typeof r
 }
 
 export async function readFileInJsonIfExists<TData = any>(...params: Parameters<typeof readFile>) {
-  const finalPath = combinePaths(params); 
-  if (existsSync(finalPath)){
+  const finalPath = combinePaths(params);
+  if (existsSync(finalPath)) {
     return await readFileInJson<TData>(...params);
   }
   return null;
@@ -102,6 +102,10 @@ export async function createDirectoryIfNotExists(directoryPath: string) {
   if (!pathExists(directoryPath)) {
     return await createDirectory(directoryPath);
   }
+}
+
+export async function deleteDirectory(directoryPath: string) {
+  return await rmSync(directoryPath, { recursive: true, force: true });
 }
 
 export async function createFile(filePath: string, fileContent?: string | Buffer) {

--- a/lib/utils/rc.util.ts
+++ b/lib/utils/rc.util.ts
@@ -21,15 +21,15 @@ export const DEFAULT_RC_FILE: IRcFileComplete = {
   },
 };
 
-export async function readRcFile(basePath: string) {
-  return readFileInJsonIfExists<IRcFile>(basePath, RC_FILE_NAME);
+export async function readRcFile(...basePath: string[]) {
+  return readFileInJsonIfExists<IRcFile>(...basePath, RC_FILE_NAME);
 }
 export type GetFieldValue<TData, TResult> = (data: TData) => TResult;
 
 export type GetRcFieldValue<TData> = GetFieldValue<IRcFile, TData>;
 
-export async function getConfigGetter(basePath: string) {
-  const data = await readRcFile(basePath);
+export async function getConfigGetter(...basePath: string[]) {
+  const data = await readRcFile(...basePath);
 
   function getConfig<TResult>(callback: GetRcFieldValue<TResult>, defaultValue?: TResult): TResult {
     return callback(data) ?? defaultValue ?? callback(DEFAULT_RC_FILE);

--- a/lib/utils/rc.util.ts
+++ b/lib/utils/rc.util.ts
@@ -5,6 +5,7 @@ export interface IRcFileComplete {
   template: {
     repository: string;
     filesPath: string;
+    branch?: string;
   };
 }
 
@@ -30,10 +31,7 @@ export type GetRcFieldValue<TData> = GetFieldValue<IRcFile, TData>;
 export async function getConfigGetter(basePath: string) {
   const data = await readRcFile(basePath);
 
-  function getConfig<TResult>(
-    callback: GetRcFieldValue<TResult>,
-    defaultValue?: TResult,
-  ): TResult {
+  function getConfig<TResult>(callback: GetRcFieldValue<TResult>, defaultValue?: TResult): TResult {
     return callback(data) ?? defaultValue ?? callback(DEFAULT_RC_FILE);
   }
   return getConfig;

--- a/lib/utils/rc.util.ts
+++ b/lib/utils/rc.util.ts
@@ -4,7 +4,6 @@ export interface IRcFileComplete {
   outDir: string;
   template: {
     repository: string;
-    filesPath: string;
     branch?: string;
   };
 }
@@ -17,7 +16,6 @@ export const DEFAULT_RC_FILE: IRcFileComplete = {
   outDir: '.metrists',
   template: {
     repository: 'https://github.com/metrists/metrists-default-theme',
-    filesPath: '/content/',
   },
 };
 

--- a/lib/utils/template-config.util.ts
+++ b/lib/utils/template-config.util.ts
@@ -1,0 +1,31 @@
+import { readFileInJsonIfExists } from './fs.util';
+
+export interface ITemplateConfig {
+  'contentPath': string;
+  'assetsPath': string;
+  'watchScript': string;
+  'buildScript': string;
+  'watchContentScript': string;
+  'buildContentScript': string;
+}
+
+export const TEMPLATE_CONFIG_FILE_NAME = 'metrists.json';
+
+export async function readConfigFile(...basePath: string[]) {
+  return readFileInJsonIfExists<ITemplateConfig>(...basePath, TEMPLATE_CONFIG_FILE_NAME);
+}
+export type GetFieldValue<TData, TResult> = (data: TData) => TResult;
+
+export type GetTemplateConfigFieldValue<TData> = GetFieldValue<ITemplateConfig, TData>;
+
+export async function getConfigGetter(...basePath: string[]) {
+  const data = await readConfigFile(...basePath);
+
+  function getConfig<TResult>(
+    callback: GetTemplateConfigFieldValue<TResult>,
+    defaultValue?: TResult,
+  ): TResult {
+    return callback(data) ?? defaultValue;
+  }
+  return getConfig;
+}


### PR DESCRIPTION
## Summary

This PR introduces metrists.json configuration file within templates. This update allows the CLI to determine and execute the appropriate scripts for dev and build processes for both content and template.

## Details

The metrists.json configuration file is used to specify the following:

contentPath: The directory where content files are located.
assetsPath: The directory where asset files are located.
watchScript: The script to run for watching changes during development.
buildScript: The script to run for building the template.
watchContentScript: The script to run for watching content changes during development.
buildContentScript: The script to run for building the content.
An example metrists.json file looks like this:

```json
{
  "contentPath": "path/to/content",
  "assetsPath": "path/to/assets",
  "watchScript": "npm run watch-template",
  "buildScript": "npm run build-template",
  "watchContentScript": "npm run watch-content",
  "buildContentScript": "npm run build-content"
}
```

### Benefits

Flexibility: Templates can now employ different technologies and file structures as long as they use npm and expose the proper scripts and paths. 
Standardization: The use of metrists.json introduces a standardized way for the CLI to interact with templates.


